### PR TITLE
Increase table height

### DIFF
--- a/app/data-table.tsx
+++ b/app/data-table.tsx
@@ -90,7 +90,7 @@ export function DataTable<TData, TValue>({
       style={{
         overflow: "auto", //our scrollable table container
         position: "relative", //needed for sticky header
-        height: "600px", //should be a fixed height
+        height: "calc(100vh - 101px)", //should be a fixed height
       }}
     >
       <div className="flex items-center py-1">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,10 +2,8 @@ import { Results } from "./results";
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-0">
-      <div className="z-10 w-full flex flex-col font-mono text-sm lg:flex">
-        <Results />
-      </div>
+    <main className="font-mono text-sm">
+      <Results />
     </main>
   );
 }

--- a/app/results.tsx
+++ b/app/results.tsx
@@ -189,7 +189,7 @@ export function Results() {
           </a>
         </div>
       </div>
-      <div className="min-h-[600px] border-b">
+      <div className="min-h-[calc(100vh-101px)] border-b">
         {results.length === 0 ? (
           <div className="px-2 py-2">Loading thousands of channels...</div>
         ) : (


### PR DESCRIPTION
Sets table height to the full page height (minus header + footer) so that more results are visible!

Video of making this same change on the live site to confirm that the table still behaves as expected:

https://github.com/davidfurlong/farcaster-channels/assets/3088615/406da30c-f9da-4289-b544-2d6cc2cfc96e

